### PR TITLE
CPH1859: setup zRam using shell script

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -81,6 +81,10 @@ PRODUCT_PACKAGES += \
     android.hidl.manager@1.0 \
     android.hidl.manager@1.0_system
 
+# zRam
+PRODUCT_PACKAGES += \
+    set_zram.sh
+
 #WiFi
 PRODUCT_PACKAGES += \
     hostapd \

--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -10,6 +10,14 @@ LOCAL_MODULE_PATH  := $(TARGET_OUT_ETC)/init
 include $(BUILD_PREBUILT)
 
 include $(CLEAR_VARS)
+LOCAL_MODULE       := set_zram.sh
+LOCAL_MODULE_TAGS  := optional
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SRC_FILES    := etc/set_zram.sh
+LOCAL_MODULE_PATH  := $(TARGET_OUT_ETC)/init
+include $(BUILD_PREBUILT)
+
+include $(CLEAR_VARS)
 LOCAL_MODULE       := fstab.mt6771
 LOCAL_MODULE_TAGS  := optional
 LOCAL_MODULE_CLASS := ETC

--- a/rootdir/etc/init.target.rc
+++ b/rootdir/etc/init.target.rc
@@ -29,3 +29,12 @@ on boot
     # OTG
     write /sys/devices/platform/odm/odm:oppo_charger/power_supply/usb/otg_switch 1
 
+service set_zram /vendor/bin/sh /system/etc/init/set_zram.sh
+    class late_start
+    disabled
+    user root
+    group system
+    oneshot
+
+on property:sys.boot_completed=1
+    start set_zram

--- a/rootdir/etc/set_zram.sh
+++ b/rootdir/etc/set_zram.sh
@@ -1,0 +1,16 @@
+#! /vendor/bin/sh
+
+# Setup ZRAM
+swapoff /dev/block/zram0
+sleep 0.5
+ZMEM=$(cat /proc/meminfo | grep MemTotal | awk  '{print $2}')
+let 'ZMEM=((ZMEM/100)*50)*1024'
+echo 1 > /sys/block/zram0/reset
+echo 'lz4' > /sys/block/zram0/comp_algorithm
+sleep 0.5
+echo $ZMEM > /sys/block/zram0/disksize
+sleep 0.5
+mkswap /dev/block/zram0
+sleep 0.5
+swapon /dev/block/zram0
+echo 100 > /proc/sys/vm/swappiness


### PR DESCRIPTION
zRam size now depend on size of device RAM and equals 50% of TotalRam
Picked from Aconitum.